### PR TITLE
update graph schema

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -13,6 +13,6 @@ REACT_APP_SENTRY_ENABLED=true
 REACT_APP_SENTRY_TRACES_SAMPLE_RATE=0.00003
 REACT_APP_STATSIG_PROXY_URL="https://api.uniswap.org/v1/statsig-proxy"
 REACT_APP_QUICKNODE_MAINNET_RPC_URL="https://ultra-blue-flower.quiknode.pro/770b22d5f362c537bc8fe19b034c45b22958f880"
-THE_GRAPH_SCHEMA_ENDPOINT="https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3?source=uniswap"
+THE_GRAPH_SCHEMA_ENDPOINT="https://v3-graph.etcswap.org/subgraphs/name/etcswap-v3/"
 REACT_APP_V2_FACTORY="0x09fafa5eecbc11C3e5d30369e51B7D9aab2f3F53"
 REACT_APP_61_V2_CODE_HASH="0xa036bc35f72d4331ca192979fb12e8a1f3260672aca44271ce35744fa5d66749"


### PR DESCRIPTION
schema is broken because of graph migration.
Fixed with new v3 endpoint.